### PR TITLE
Add user generated reports to posts and  comments

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,4 +11,8 @@ class ApplicationController < ActionController::Base
       end
     end
   end
+
+  def current_subject
+      Subject.find(session[:last_subject_id])
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  # before_action :authenticate_user!
+  helper_method :mistake_count
   
   def check_permission(object)
     unless object.user_id == current_user.id
@@ -13,10 +13,16 @@ class ApplicationController < ActionController::Base
   end
 
   def current_subject
-      Subject.find(session[:last_subject_id])
+    Subject.find(session[:last_subject_id])
   end
 
   def current_post 
     Post.find(session[:last_post_id])
+  end
+
+  def mistake_count(object)
+    object.reports.count do |report|
+      report.reason == "Mistake"
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,4 +15,8 @@ class ApplicationController < ActionController::Base
   def current_subject
       Subject.find(session[:last_subject_id])
   end
+
+  def current_post 
+    Post.find(session[:last_post_id])
+  end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -42,8 +42,4 @@ class CommentsController < ApplicationController
   def comment_params
     params.require(:comment).permit(:body)
   end
-
-  def current_post 
-    Post.find(session[:last_post_id])
-  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,11 +4,7 @@ class PostsController < ApplicationController
     controller.check_permission(@post)
   end
 
-  def show
-    @mistake_count=@post.reports.count do |report|
-      report.reason == "Mistake"
-    end
-  end
+  def show; end
 
   def new
     @post=current_subject.posts.build

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,11 @@ class PostsController < ApplicationController
     controller.check_permission(@post)
   end
 
-  def show; end
+  def show
+    @mistake_count=@post.reports.count do |report|
+      report.reason == "Mistake"
+    end
+  end
 
   def new
     @post=current_subject.posts.build

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -51,8 +51,4 @@ class PostsController < ApplicationController
   def post_params 
     params.require(:post).permit(:title, :body, :document)
   end
-
-  def current_subject
-      Subject.find(session[:last_subject_id])
-  end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,5 +1,8 @@
 class ReportsController < ApplicationController
-before_action :find_reporter, only: [:new, :create]
+  before_action :find_reporter
+  before_action only: [:mark_as_resolved] do |controller|
+    controller.check_permission(@reporter)
+  end
 
   def new
     @report=@reporter.reports.build

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,0 +1,31 @@
+class ReportsController < ApplicationController
+before_action :find_reporter
+
+  def new
+    @report=@reporter.reports.build
+  end
+
+  def create
+    @report=@reporter.reports.build(report_params)
+    @report.user_id=current_user.id
+
+    respond_to do |format|
+      if @report.save
+        format.html { redirect_to current_subject, notice: 'Report was successfully created.' }
+      else
+        format.html { render :new }
+      end
+    end
+  end
+
+  private
+
+  def report_params
+    params.require(:report).permit(:reason, :description, :resolved)
+  end
+
+  def find_reporter
+      @klass=params[:reporter_type].capitalize.constantize
+      @reporter=@klass.find(params[:reporter_id])
+  end
+end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,5 +1,5 @@
 class ReportsController < ApplicationController
-before_action :find_reporter
+before_action :find_reporter, only: [:new, :create]
 
   def new
     @report=@reporter.reports.build
@@ -14,6 +14,15 @@ before_action :find_reporter
         format.html { redirect_to current_subject, notice: 'Report was successfully created.' }
       else
         format.html { render :new }
+      end
+    end
+  end
+
+  def mark_as_resolved
+    @report=Report.find(params[:id])
+    respond_to do |format|
+      if @report.update(resolved: true)
+        format.html { redirect_to current_post, notice: 'Report was marked as resolved' }
       end
     end
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,6 +1,7 @@
 class Comment < ApplicationRecord
   belongs_to :commentable, polymorphic: true
   belongs_to :user
+  has_many :reports, as: :reportable
 
   validates :body, presence: true
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,6 +3,7 @@ class Post < ApplicationRecord
   belongs_to :user
   has_many :comments, as: :commentable
   has_many :likes, as: :likeable
+  has_many :reports, as: :reportable
 
   has_one_attached :document
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,0 +1,10 @@
+class Report < ApplicationRecord
+  belongs_to :user
+  belongs_to :reportable, polymorphic: true
+
+  validates :reason, presence: true, format:
+    {
+      with: /\A(Inappropriate Content|Mistake)/,
+      message: 'Invalid type'
+    }
+end

--- a/app/views/posts/_mistake_list.erb
+++ b/app/views/posts/_mistake_list.erb
@@ -1,0 +1,36 @@
+<% if object.reports.exists? %>
+  <% unless mistake_count(object) == object.reports.count %>
+    <p>
+      <strong>
+        This <%= object.class.to_s.downcase %> 
+        has been reported for innapropriate content
+      </strong>
+    </p>
+  <% end %>
+
+  <p>
+    <strong> This <%= object.class.to_s.downcase %>
+    has <%= pluralize(mistake_count(object), 'reported mistake') %> </strong>
+  </p>
+
+  <ul>
+    <% object.reports.each do |report| %>
+      <% if report.reason == "Mistake" %>
+        <li> <%= report.description %>
+
+          <% if report.resolved %>
+            <strong> Marked as resolved by author </strong>
+          <% elsif object.user_id==current_user.id %>
+            <%= link_to 'Mark as resolved', 
+            mark_report_as_resolved_path(
+              report,
+              reporter_id: object.id,
+              reporter_type: object.class.to_s.to_sym
+              ),
+            method: :patch %>
+          <% end %>
+        </li>
+      <% end %>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -2,12 +2,28 @@
 
 <h1> <%=@post.subject.name%> </h1>
 
-<h3> <%=@post.title %> </h3>
+<h2> <%=@post.title %> </h2>
 
 <p> 
   <i> Posted by <%= @post.user.email %> </i> 
 </p>
 
+<% if @post.reports.exists? %>
+  <% mistake_count=@post.reports.count do |report| %>
+    <% report.reason == "Mistake" %>
+  <% end %>
+  <% unless mistake_count == @post.reports.count %>
+    <h3> This post has been reported for innapropriate content </h3>
+  <% end %>
+  <h3> This post has had <%= pluralize(mistake_count, 'mistake') %> reported </h3>
+  <ul>
+  <% @post.reports.each do |report| %>
+    <% if report.reason == "Mistake" %>
+      <li> <%= report.description %>
+    <% end %>
+  <% end %>
+  </ul>
+<% end %>
 <p>
   <%= @post.body  %>
 </p>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -12,17 +12,29 @@
   <% mistake_count=@post.reports.count do |report| %>
     <% report.reason == "Mistake" %>
   <% end %>
+
   <% unless mistake_count == @post.reports.count %>
     <h3> This post has been reported for innapropriate content </h3>
   <% end %>
-  <h3> This post has had <%= pluralize(mistake_count, 'mistake') %> reported </h3>
+
+  <h3> This post has <%= pluralize(mistake_count, 'reported mistake') %> </h3>
+
   <ul>
   <% @post.reports.each do |report| %>
     <% if report.reason == "Mistake" %>
       <li> <%= report.description %>
+
+      <% if report.resolved %>
+        <strong> Marked as resolved by author </strong>
+      <% elsif @post.user_id==current_user.id %>
+        <%= link_to 'Mark as resolved', 
+        mark_report_as_resolved_path(report),
+        resolved: true, method: :patch %>
+      <% end %>
     <% end %>
   <% end %>
   </ul>
+
 <% end %>
 <p>
   <%= @post.body  %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -29,14 +29,16 @@
 </p>
 
 <%= link_to 'Edit', edit_post_path(@post) %> |
-<%= link_to 'Back', @post.subject %>
+<%= link_to 'Back', @post.subject %> |
+<%= link_to 'Report', new_report_path(reporter_id: @post.id, reporter_type: @post.class.to_s.to_sym) %>
 
 <ul>
   <% @post.comments.each do |comment| %>
     <li>
       <strong> <%= comment.user.email %> <strong>     
+      <%= link_to 'Report', new_report_path(reporter_id: comment.id, reporter_type: comment.class.to_s.to_sym) %>
       <p> 
-        <%= comment.body %> | <%= link_to 'Edit', edit_comment_path(comment) %>
+        <%= comment.body %>
       </p>
     </li>
   <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -9,15 +9,11 @@
 </p>
 
 <% if @post.reports.exists? %>
-  <% mistake_count=@post.reports.count do |report| %>
-    <% report.reason == "Mistake" %>
-  <% end %>
-
-  <% unless mistake_count == @post.reports.count %>
+  <% unless @mistake_count == @post.reports.count %>
     <h3> This post has been reported for innapropriate content </h3>
   <% end %>
 
-  <h3> This post has <%= pluralize(mistake_count, 'reported mistake') %> </h3>
+  <h3> This post has <%= pluralize(@mistake_count, 'reported mistake') %> </h3>
 
   <ul>
   <% @post.reports.each do |report| %>
@@ -28,8 +24,12 @@
         <strong> Marked as resolved by author </strong>
       <% elsif @post.user_id==current_user.id %>
         <%= link_to 'Mark as resolved', 
-        mark_report_as_resolved_path(report),
-        resolved: true, method: :patch %>
+        mark_report_as_resolved_path(
+          report,
+          reporter_id: @post.id,
+          reporter_type: @post.class.to_s.to_sym
+          ),
+        method: :patch %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -8,34 +8,8 @@
   <i> Posted by <%= @post.user.email %> </i> 
 </p>
 
-<% if @post.reports.exists? %>
-  <% unless @mistake_count == @post.reports.count %>
-    <h3> This post has been reported for innapropriate content </h3>
-  <% end %>
+<%= render 'mistake_list', object: @post %>
 
-  <h3> This post has <%= pluralize(@mistake_count, 'reported mistake') %> </h3>
-
-  <ul>
-  <% @post.reports.each do |report| %>
-    <% if report.reason == "Mistake" %>
-      <li> <%= report.description %>
-
-      <% if report.resolved %>
-        <strong> Marked as resolved by author </strong>
-      <% elsif @post.user_id==current_user.id %>
-        <%= link_to 'Mark as resolved', 
-        mark_report_as_resolved_path(
-          report,
-          reporter_id: @post.id,
-          reporter_type: @post.class.to_s.to_sym
-          ),
-        method: :patch %>
-      <% end %>
-    <% end %>
-  <% end %>
-  </ul>
-
-<% end %>
 <p>
   <%= @post.body  %>
 </p>
@@ -62,12 +36,16 @@
 
 <ul>
   <% @post.comments.each do |comment| %>
-    <li>
-      <strong> <%= comment.user.email %> <strong>     
-      <%= link_to 'Report', new_report_path(reporter_id: comment.id, reporter_type: comment.class.to_s.to_sym) %>
-      <p> 
-        <%= comment.body %>
-      </p>
-    </li>
+    <% unless comment.reports.any? { |report| report.reason == "Inappropriate Content" } %>
+      <li>
+        <strong> <%= comment.user.email %> </strong>     
+        <%= link_to 'Report', new_report_path(reporter_id: comment.id, reporter_type: comment.class.to_s.to_sym) %>
+
+        <%= render 'mistake_list', object: comment %>
+        <p> 
+          <%= comment.body %>
+        </p>
+      </li>
+    <% end %>
   <% end %>
 <ul>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -23,7 +23,7 @@
 
   <div class="field">
     <%= form.label :reason %>
-    <%= form.select :reason, ['Inappropriate Content', 'Mistake'] %>
+    <%= form.select :reason, ['Mistake', 'Inappropriate Content'] %>
   </div>
 
   <div class="field">

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -1,0 +1,41 @@
+<%= form_with(
+  model: report,
+  url: reports_path(
+    reporter_type: @reporter.class.to_s.to_sym,
+    reporter_id: @reporter.id
+  ),
+  local: true
+) do |form| %>
+  <% if report.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= pluralize(report.errors.count, "error") %> 
+        prohibited this report from being saved:
+      </h2>
+
+      <ul>
+        <% report.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :reason %>
+    <%= form.select :reason, ['Inappropriate Content', 'Mistake'] %>
+  </div>
+
+  <div class="field">
+    <%= form.label :description %>
+    <%= form.text_area :description %>
+  </div>
+
+  <div class="field">
+    <%= form.hidden_field :resolved, value: false %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,0 +1,4 @@
+<h1>New Report</h1>
+
+<%= render 'form', report: @report %>
+<%= link_to 'Back', @reporter %>

--- a/app/views/subjects/show.html.erb
+++ b/app/views/subjects/show.html.erb
@@ -27,7 +27,9 @@
 
 <% @subject.posts.each do |post|%>
   <p>
-    <%=link_to post.title, post%>
+    <% unless post.reports.any? { |report| report.reason == "Inappropriate Content" } %>
+      <%=link_to post.title, post%>
+    <% end %>
   </p>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   resources :posts, only: [:show, :new, :create, :edit, :update, :destroy]
   resources :likes, only: [:create, :destroy]
   resources :reports, only: [:new, :create]
+  patch 'reports/:id/mark_as_resolved', to: 'reports#mark_as_resolved', as: 'mark_report_as_resolved'
   root to: 'pages#home'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'reports/create'
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   devise_for :users
@@ -7,6 +8,7 @@ Rails.application.routes.draw do
   resources :subjects
   resources :posts, only: [:show, :new, :create, :edit, :update, :destroy]
   resources :likes, only: [:create, :destroy]
+  resources :reports, only: [:new, :create]
   root to: 'pages#home'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20190731103230_create_reports.rb
+++ b/db/migrate/20190731103230_create_reports.rb
@@ -1,0 +1,13 @@
+class CreateReports < ActiveRecord::Migration[6.0]
+  def change
+    create_table :reports do |t|
+      t.string :reason
+      t.text :description
+      t.boolean :resolved, default: :false
+      t.references :user, null: false, foreign_key: true, index: true
+      t.references :reportable, polymorphic: true, null: false, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_31_103230) do
+ActiveRecord::Schema.define(version: 2019_08_02_104915) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -118,6 +118,13 @@ ActiveRecord::Schema.define(version: 2019_07_31_103230) do
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
+  create_table "posts_tags", id: false, force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.bigint "tag_id", null: false
+    t.index ["post_id", "tag_id"], name: "index_posts_tags_on_post_id_and_tag_id"
+    t.index ["tag_id", "post_id"], name: "index_posts_tags_on_tag_id_and_post_id"
+  end
+
   create_table "reports", force: :cascade do |t|
     t.string "reason"
     t.text "description"
@@ -144,6 +151,13 @@ ActiveRecord::Schema.define(version: 2019_07_31_103230) do
     t.bigint "user_id", null: false
     t.index ["subject_id", "user_id"], name: "index_subjects_users_on_subject_id_and_user_id"
     t.index ["user_id", "subject_id"], name: "index_subjects_users_on_user_id_and_subject_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "color"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_29_103707) do
+ActiveRecord::Schema.define(version: 2019_07_31_103230) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -118,6 +118,19 @@ ActiveRecord::Schema.define(version: 2019_07_29_103707) do
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
+  create_table "reports", force: :cascade do |t|
+    t.string "reason"
+    t.text "description"
+    t.boolean "resolved", default: false
+    t.bigint "user_id", null: false
+    t.string "reportable_type", null: false
+    t.bigint "reportable_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["reportable_type", "reportable_id"], name: "index_reports_on_reportable_type_and_reportable_id"
+    t.index ["user_id"], name: "index_reports_on_user_id"
+  end
+
   create_table "subjects", force: :cascade do |t|
     t.string "name"
     t.integer "year"
@@ -151,4 +164,5 @@ ActiveRecord::Schema.define(version: 2019_07_29_103707) do
   add_foreign_key "likes", "users"
   add_foreign_key "posts", "subjects"
   add_foreign_key "posts", "users"
+  add_foreign_key "reports", "users"
 end


### PR DESCRIPTION
User can generate reports. Reports can either be for mistakes or for inappropriate content.

The author of the content that was reported can mark mistakes as resolved, and it will display as such. Only admins can remove reports.

Reports are displayed above the piece of content. A report for inappropriate content hides that piece of content from index pages, though it still exists.